### PR TITLE
Upgrade to JDK6

### DIFF
--- a/maven2-plugins/myfaces-builder-annotations/pom.xml
+++ b/maven2-plugins/myfaces-builder-annotations/pom.xml
@@ -35,7 +35,7 @@
   <name>Apache MyFaces Buildtools Maven2 Builder Annotations</name>
 
   <description>
-    A set of Java 1.5 Annotation classes that can be applied to classes that are
+    A set of Java 1.6 Annotation classes that can be applied to classes that are
     intended to be JSF components, validators, etc. The maven-builder-plugin will
     recognise these annotations and process the class appropriately.
   </description>
@@ -53,8 +53,8 @@
         <version>2.0.2</version>
         <inherited>true</inherited>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
     </plugins>

--- a/maven2-plugins/myfaces-faces-plugin/pom.xml
+++ b/maven2-plugins/myfaces-faces-plugin/pom.xml
@@ -51,8 +51,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <source>1.4</source>
-          <target>1.4</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/maven2-plugins/myfaces-i18n-plugin/pom.xml
+++ b/maven2-plugins/myfaces-i18n-plugin/pom.xml
@@ -47,8 +47,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <source>1.4</source>
-          <target>1.4</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/maven2-plugins/myfaces-javacc-plugin/pom.xml
+++ b/maven2-plugins/myfaces-javacc-plugin/pom.xml
@@ -68,6 +68,25 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>2.2</version>
+      </plugin>
+    </plugins>
+  </build>
+  
   <reporting>
     <plugins>
       <plugin>

--- a/maven2-plugins/myfaces-javascript-plugin/pom.xml
+++ b/maven2-plugins/myfaces-javascript-plugin/pom.xml
@@ -47,8 +47,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/maven2-plugins/myfaces-jdev-plugin/pom.xml
+++ b/maven2-plugins/myfaces-jdev-plugin/pom.xml
@@ -63,6 +63,25 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>2.2</version>
+      </plugin>
+    </plugins>
+  </build>
+  
   <reporting>
     <plugins>
       <plugin>

--- a/maven2-plugins/myfaces-jsdoc-plugin/pom.xml
+++ b/maven2-plugins/myfaces-jsdoc-plugin/pom.xml
@@ -57,8 +57,8 @@
               <version>2.0.2</version>
               <inherited>true</inherited>
               <configuration>
-                <source>1.5</source>
-                <target>1.5</target>
+                <source>1.6</source>
+                <target>1.6</target>
               </configuration>
             </plugin>
         </plugins>

--- a/maven2-plugins/myfaces-plugin-parent/pom.xml
+++ b/maven2-plugins/myfaces-plugin-parent/pom.xml
@@ -136,7 +136,7 @@
           </rulesets>
           <linkXref>true</linkXref>
           <minimumTokens>100</minimumTokens>
-          <targetJdk>1.5</targetJdk>
+          <targetJdk>1.6</targetJdk>
         </configuration>
         -->
       </plugin>

--- a/maven2-plugins/myfaces-tagdoc-plugin/pom.xml
+++ b/maven2-plugins/myfaces-tagdoc-plugin/pom.xml
@@ -47,8 +47,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <source>1.4</source>
-          <target>1.4</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
     </plugins>

--- a/maven2-plugins/myfaces-wagon-plugin/pom.xml
+++ b/maven2-plugins/myfaces-wagon-plugin/pom.xml
@@ -50,6 +50,22 @@
         <version>1.0-alpha-5</version>
       </extension>
     </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>2.2</version>
+      </plugin>
+    </plugins>
   </build>
   <dependencies>
     <dependency>
@@ -83,6 +99,7 @@
     </snapshotRepository>
   </distributionManagement>
 
+  
   <reporting>
     <plugins>
       <plugin>

--- a/maven2-plugins/myfaces-xrts-plugin/pom.xml
+++ b/maven2-plugins/myfaces-xrts-plugin/pom.xml
@@ -48,8 +48,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <inherited>true</inherited>
           <configuration>
-            <source>1.5</source>
-            <target>1.5</target>
+            <source>1.6</source>
+            <target>1.6</target>
             <showWarnings>true</showWarnings>
             <compilerArgument>-Xlint:all,-serial,-fallthrough</compilerArgument>
           </configuration>

--- a/maven2-plugins/pom.xml
+++ b/maven2-plugins/pom.xml
@@ -68,4 +68,23 @@
     <module>myfaces-xrts-plugin</module>
   </modules>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>2.2</version>
+      </plugin>
+    </plugins>
+  </build>
+  
 </project>


### PR DESCRIPTION
Doing a fresh checkout with JDK and Maven 3.8.3 these were the build errors I was receiving...

```
[INFO] Reactor Summary:
[INFO]
[INFO] Apache MyFaces Buildtools Maven2 Plugin Parent 1.0.7-SNAPSHOT SUCCESS [  1.732 s]
[INFO] Apache MyFaces Buildtools Maven2 Builder Annotations 1.0.10-SNAPSHOT FAILURE [  0.412 s]
[INFO] Apache MyFaces Buildtools Maven2 Builder Plugin 1.0.12-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 Faces Plugin 1.0.1-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 i18n Plugin 1.0.1-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 Javacc Plugin 1.0.2-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 Javascript Plugin 1.0.3-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 Javascript Documentation Plugin 1.0-beta-2-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 JDev Plugin 1.0.1-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 Tag Documentation Report 1.0.1-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 Wagon Plugin 1.0.1-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 XRTS Plugin 1.0.1-SNAPSHOT SKIPPED
[INFO] Apache MyFaces Buildtools Maven2 Plugin Module 1-SNAPSHOT SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.561 s
[INFO] Finished at: 2021-09-19T08:25:39-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project myfaces-builder-annotations: Compilation failure: Compilation failure:
[ERROR] error: Source option 5 is no longer supported. Use 6 or later.
[ERROR] error: Target option 1.5 is no longer supported. Use 1.6 or later.
```

These changes were the bare minimum I could make to get this to build all the plugins locally.