### PR TITLE
MYFACES-4429: Remove log4J as its not used

### DIFF
--- a/maven2-plugins/myfaces-builder-plugin/pom.xml
+++ b/maven2-plugins/myfaces-builder-plugin/pom.xml
@@ -259,10 +259,5 @@
     </dependency>
     <!-- End Reporting required API -->
 
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.13</version>
-    </dependency>
   </dependencies>
 </project>

--- a/maven2-plugins/myfaces-tagdoc-plugin/pom.xml
+++ b/maven2-plugins/myfaces-tagdoc-plugin/pom.xml
@@ -132,12 +132,6 @@
       <artifactId>commons-logging</artifactId>
       <version>1.0.4</version>
     </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.12</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <reporting>

--- a/maven2-plugins/myfaces-wagon-plugin/pom.xml
+++ b/maven2-plugins/myfaces-wagon-plugin/pom.xml
@@ -120,7 +120,6 @@
             <link>http://jakarta.apache.org/commons/logging/apidocs/</link>
             <link>http://jakarta.apache.org/commons/pool/apidocs/</link>
             <link>http://www.junit.org/junit/javadoc/</link>
-            <link>http://logging.apache.org/log4j/docs/api/</link>
             <link>http://jakarta.apache.org/regexp/apidocs/</link>
             <link>http://jakarta.apache.org/velocity/api/</link>
           </links>


### PR DESCRIPTION
This JAR is not even being used and everything uses java.util.logging or apache.commons logging in the Java files