### PR TITLE
Exclude files in myfaces-builder-plugin

### DIFF
--- a/maven2-plugins/myfaces-builder-plugin/src/main/java/org/apache/myfaces/buildtools/maven2/plugin/builder/IOUtils.java
+++ b/maven2-plugins/myfaces-builder-plugin/src/main/java/org/apache/myfaces/buildtools/maven2/plugin/builder/IOUtils.java
@@ -440,7 +440,7 @@ public class IOUtils
             }
             else
             {
-                new File((String) i.next());
+                srcDir = new File(dir.toString());
             }
             //Scan all files on directory and add to builder
             addFileToJavaDocBuilder(visitor, selector, srcDir);


### PR DESCRIPTION
`com.thoughtworks.qdox` doesn't support newer java syntax (i.e `default` on interfaces), and upgrading is out of the question due numerous breaking API changes.


Next best options is to add behavior to exclude processing on specific files. 


Example: 

```
                    <execution>
                        <id>makecomp</id>
                        <configuration>
                            <jsfVersion>20</jsfVersion>
                            <templateComponentName>componentClass20.vm</templateComponentName>
                            <excludes>**/package.html</excludes>
                        </configuration>
                        <goals>
                            <goal>make-components</goal>
                        </goals>
                    </execution>

```
or
```
            <plugin>
                <groupId>org.apache.myfaces.buildtools</groupId>
                <artifactId>myfaces-builder-plugin</artifactId>
                <executions>
                    <execution>
                        <configuration>
                            <excludes>**/src/main/java/jakarta/faces/component/ActionSource.java</excludes>
                        </configuration>
                        <goals>
                            <goal>build-metadata</goal>
                        </goals>
                    </execution>
                    <execution>
                        <id>makecomp</id>
                        <configuration>
                            <jsfVersion>20</jsfVersion>
                            <templateComponentName>componentClass20.vm</templateComponentName>
                            <excludes>**/src/main/java/jakarta/faces/component/ActionSource.java</excludes>
                            <force>true</force>
                        </configuration>
                        <goals>
                            <goal>make-components</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
```