### PR TITLE
Remove unneeded HTML attribute `type` for `script` tag

### DIFF
--- a/maven2-plugins/myfaces-javascript-plugin/src/test/resources/jsunit/jsUnitAssertionTests.html
+++ b/maven2-plugins/myfaces-javascript-plugin/src/test/resources/jsunit/jsUnitAssertionTests.html
@@ -45,8 +45,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>JsUnit Assertion Tests</title>
     <link rel="stylesheet" type="text/css" href="css/jsUnitStyle.css">
-<script language="JavaScript" type="text/javascript" src="app/jsUnitCore.js"></script>
-<script language="JavaScript" type="text/javascript">
+<script language="JavaScript" src="app/jsUnitCore.js"></script>
+<script language="JavaScript">
 
 // JsUnit Assertion Tests
 function testAssert() {

--- a/maven2-plugins/myfaces-javascript-plugin/src/test/resources/scripts/scriptaculous.js
+++ b/maven2-plugins/myfaces-javascript-plugin/src/test/resources/scripts/scriptaculous.js
@@ -27,7 +27,7 @@ var Scriptaculous = {
   Version: '1.7.0',
   require: function(libraryName) {
     // inserting via DOM fails in Safari 2.0, so brute force approach
-    document.write('<script type="text/javascript" src="'+libraryName+'"></script>');
+    document.write('<script src="'+libraryName+'"></script>');
   },
   load: function() {
     if((typeof Prototype=='undefined') || 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type

"Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type."