### PR TITLE
Remove deprecated `language` attribute from HTML `script` tags

### DIFF
--- a/maven2-plugins/myfaces-javascript-plugin/src/test/resources/jsunit/jsUnitAssertionTests.html
+++ b/maven2-plugins/myfaces-javascript-plugin/src/test/resources/jsunit/jsUnitAssertionTests.html
@@ -45,8 +45,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>JsUnit Assertion Tests</title>
     <link rel="stylesheet" type="text/css" href="css/jsUnitStyle.css">
-<script language="JavaScript" src="app/jsUnitCore.js"></script>
-<script language="JavaScript">
+<script src="app/jsUnitCore.js"></script>
+<script>
 
 // JsUnit Assertion Tests
 function testAssert() {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#deprecated_attributes